### PR TITLE
Slim down image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,13 +27,12 @@ RUN \
 RUN cd /usr/local/ && curl -L -O http://dl.google.com/android/android-sdk_r24.4.1-linux.tgz && tar xf android-sdk_r24.4.1-linux.tgz && \
     echo y | /usr/local/android-sdk-linux/tools/android update sdk --no-ui --force --all --filter "tools" && \
     echo y | /usr/local/android-sdk-linux/tools/android update sdk --no-ui --force --all --filter "platform-tools,build-tools-24.0.1,android-24" && \
-    echo y | /usr/local/android-sdk-linux/tools/android update sdk --no-ui --force --all --filter "extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository,addon-google_apis-google-23"
+    echo y | /usr/local/android-sdk-linux/tools/android update sdk --no-ui --force --all --filter "extra-google-google_play_services,extra-google-m2repository,extra-android-m2repository,addon-google_apis-google-23" && \
+    rm -rf /usr/local/android-sdk_r24.4.1-linux.tgz
 
 # Install Android NDK
-RUN cd /usr/local && curl -L -O http://dl.google.com/android/ndk/android-ndk-r9b-linux-x86_64.tar.bz2 && tar xf android-ndk-r9b-linux-x86_64.tar.bz2
-
-# Install Gradle
-RUN cd /usr/local/ && curl -L -O https://services.gradle.org/distributions/gradle-2.14-all.zip && unzip -o gradle-2.14-all.zip
+RUN cd /usr/local && curl -L -O http://dl.google.com/android/ndk/android-ndk-r9b-linux-x86_64.tar.bz2 && tar xf android-ndk-r9b-linux-x86_64.tar.bz2 && \
+    rm -rf /usr/local/android-ndk-r9b-linux-x86_64.tar.bz2
 
 # Environment variables
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
@@ -47,7 +46,3 @@ ENV PATH $PATH:$ANDROID_HOME/platform-tools
 ENV PATH $PATH:$ANDROID_NDK_HOME
 ENV PATH $PATH:$GRADLE_HOME/bin
 
-# Clean up
-RUN rm -rf /usr/local/android-sdk_r24.4.1-linux.tgz
-RUN rm -rf /usr/local/android-ndk-r9b-linux-x86_64.tar.bz2
-RUN rm -rf /usr/local/gradle-2.14-all.zip


### PR DESCRIPTION
Removes install files on each layer.
It will also not install gradle. Builds usually use the wrapper anyways.

This change reduces 0.908 GB of image size. From 4.726 GB to 3.818 GB.
